### PR TITLE
added Makefile for good old gcc (or clang)

### DIFF
--- a/src/Makefile.linux.gcc
+++ b/src/Makefile.linux.gcc
@@ -1,0 +1,15 @@
+CC = gcc
+CFLAGS  = -Wall
+RM = del
+EXTENSION = 
+
+all: zx1 dzx1
+
+zx1: zx1.c optimize.c compress.c memory.c zx1.h
+	$(CC) $(CFLAGS) -o zx1$(EXTENSION) zx1.c optimize.c compress.c memory.c
+
+dzx1: dzx1.c
+	$(CC) $(CFLAGS) -o dzx1$(EXTENSION) dzx1.c
+
+clean:
+	$(RM) *.obj


### PR DESCRIPTION
Hello. I have added the Makefile for gcc/clang compilers. Could you please add it to let people to compile it without installing  wattcom compiler?

Thanks in advance
Jakub Husak